### PR TITLE
[Fix] Allow requests to actually send JSON (or hopefully XML).

### DIFF
--- a/src/HappyR/LinkedIn/Http/RequestInterface.php
+++ b/src/HappyR/LinkedIn/Http/RequestInterface.php
@@ -14,5 +14,5 @@ namespace HappyR\LinkedIn\Http;
  */
 interface RequestInterface
 {
-    public function send($url, $params=array(), $method='GET');
+    public function send($url, $params = array(), $method = 'GET', $contentType = null);
 }

--- a/src/HappyR/LinkedIn/LinkedIn.php
+++ b/src/HappyR/LinkedIn/LinkedIn.php
@@ -157,7 +157,7 @@ class LinkedIn
         $url=$this->getUrlGenerator()->getUrl('api', $resource, $urlParams);
 
         //$method that url
-        $result= $this->getRequest()->send($url, $postParams, $method);
+        $result = $this->getRequest()->send($url, $postParams, $method, $urlParams['format']);
 
         if ($urlParams['format']=='json') {
             return json_decode($result, true);

--- a/tests/HappyR/LinkedIn/LinkedInTest.php
+++ b/tests/HappyR/LinkedIn/LinkedInTest.php
@@ -43,6 +43,7 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
         $method='GET';
         $expected=array('foobar'=>'test');
         $url='http://example.com/test';
+        $format='json';
 
         $generator = m::mock('HappyR\LinkedIn\Http\UrlGenerator')
             ->shouldReceive('getUrl')->once()->with(
@@ -51,12 +52,12 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
                 array(
                     'url'=>'foo',
                     'oauth2_access_token'=>$token,
-                    'format'=>'json',
+                    'format'=>$format,
                 ))->andReturn($url)
             ->getMock();
 
         $request = m::mock('HappyR\LinkedIn\Http\RequestInterface')
-            ->shouldReceive('send')->once()->with($url, $postParams, $method)->andReturn(json_encode($expected))
+            ->shouldReceive('send')->once()->with($url, $postParams, $method, $format)->andReturn(json_encode($expected))
             ->getMock();
 
         $linkedIn=m::mock('HappyR\LinkedIn\LinkedIn[getAccessToken,getUrlGenerator,getRequest]', array('id', 'secret'))


### PR DESCRIPTION
- First off, who's really gonna use the XML? I didn't really test with that, but JSON seemed to be working for what I was doing and the tests pass.
- Set the proper headers to actually send JSON or XML and then send JSON or XML instead of http_build_query every time (format sensitive and falls back to the old behavior).
- Remove code that made it look like you could actually pass a curl handle and all that stuff. It wasn't being used and looked funny.
- Fixes #4.
