### PR TITLE
Add option to disable SSL peer verify

### DIFF
--- a/src/HappyR/LinkedIn/Http/Request.php
+++ b/src/HappyR/LinkedIn/Http/Request.php
@@ -22,6 +22,7 @@ class Request implements RequestInterface
         CURLOPT_RETURNTRANSFER => true,
         CURLOPT_TIMEOUT        => 60,
         CURLOPT_USERAGENT      => 'linkedin-php-client',
+        //CURLOPT_SSL_VERIFYPEER => false
     );
 
     /**


### PR DESCRIPTION
I am using Azure cloud, and it looks like Linkedin SSL certificate is not recognized by Azure website virtual machine. Setting this option to false is fixing this.

I don't know how to integrate it to your library, sorry for the dirty PR ;-)