### PR TITLE
Added test if session is started before using SessionStorage.

### DIFF
--- a/src/HappyR/LinkedIn/Storage/SessionStorage.php
+++ b/src/HappyR/LinkedIn/Storage/SessionStorage.php
@@ -16,11 +16,33 @@ class SessionStorage implements DataStorageInterface
 {
     public static $validKeys = array('state', 'code', 'access_token', 'user');
 
+    protected $ignoreNonActiveSession = false;
+
+    /**
+     * @param bool $ignoreNonActiveSession
+     */
+    public function __construct($ignoreNonActiveSession = false)
+    {
+        $this->ignoreNonActiveSession = $ignoreNonActiveSession;
+    }
+
+    /**
+     * @param bool $ignore
+     */
+    public function ignoreNonActiveSession($ignore = true)
+    {
+        $this->ignoreNonActiveSession = $ignore;
+    }
+
     /**
      * {@inheritDoc}
      */
     public function set($key, $value)
     {
+        if (!$this->ignoreNonActiveSession && session_status() == PHP_SESSION_NONE) {
+            throw new LinkedInApiException("There is no active session to be used for storage.");
+        }
+
         if (!in_array($key, self::$validKeys)) {
             throw new LinkedInApiException(sprintf('Unsupported key ("%s") passed to set.', $key));
         }
@@ -34,6 +56,10 @@ class SessionStorage implements DataStorageInterface
      */
     public function get($key, $default = false)
     {
+        if (!$this->ignoreNonActiveSession && session_status() == PHP_SESSION_NONE) {
+            throw new LinkedInApiException("There is no active session to be used for storage.");
+        }
+
         if (!in_array($key, self::$validKeys)) {
             return $default;
         }
@@ -47,6 +73,10 @@ class SessionStorage implements DataStorageInterface
      */
     public function clear($key)
     {
+        if (!$this->ignoreNonActiveSession && session_status() == PHP_SESSION_NONE) {
+            throw new LinkedInApiException("There is no active session to be used for storage.");
+        }
+
         if (!in_array($key, self::$validKeys)) {
             throw new LinkedInApiException(sprintf('Unsupported key ("%s") passed to clear.', $key));
         }

--- a/tests/HappyR/LinkedIn/Storage/IlluminateSessionStorageTest.php
+++ b/tests/HappyR/LinkedIn/Storage/IlluminateSessionStorageTest.php
@@ -23,7 +23,7 @@ class IlluminateSessionStorageTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->storage = new IlluminateSessionStorage();
+        $this->storage = new IlluminateSessionStorage(true);
     }
 
     public function testSet()

--- a/tests/HappyR/LinkedIn/Storage/SessionStorageTest.php
+++ b/tests/HappyR/LinkedIn/Storage/SessionStorageTest.php
@@ -23,7 +23,8 @@ class SessionStorageTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->storage=new SessionStorage();
+        $this->storage=new SessionStorage(true);
+        $this->storage->ignoreNonActiveSession();
     }
 
     public function testSet()
@@ -77,7 +78,10 @@ class SessionStorageTest extends \PHPUnit_Framework_TestCase
     {
         $validKeys=SessionStorage::$validKeys;
 
-        $storage = m::mock('HappyR\LinkedIn\Storage\SessionStorage[clear]')
+        $storage = m::mock(
+                'HappyR\LinkedIn\Storage\SessionStorage'
+                .'[clear]'
+            )
             ->shouldReceive('clear')->times(count($validKeys))
             ->with(m::on(function($arg) use ($validKeys){
                 return in_array($arg, $validKeys);
@@ -87,4 +91,13 @@ class SessionStorageTest extends \PHPUnit_Framework_TestCase
         $storage->clearAll();
     }
 
-} 
+    /**
+     * @expectedException \HappyR\LinkedIn\Exceptions\LinkedInApiException
+     */
+    public function testDoesntAllowToReadIfTheSessionIsNotStarted()
+    {
+        $storage = new SessionStorage();
+
+        $value = $storage->get('test');
+    }
+}


### PR DESCRIPTION
Hi @Nyholm 

I like your library a lot, it helps me built my project. However I have noticed issue if I don't have a php session started, there is following error showing on:

```
Fatal error: Uncaught Exception: CSRF state token does not match one provided. thrown in /var/www/html/filipgorny/vendor/happyr/linkedin-api-client/src/HappyR/LinkedIn/LinkedIn.php on line 300
```

I have resolved it by the following commit and I thought you may consider it to merge.