### PR TITLE
Introduce access token object

### DIFF
--- a/src/Happyr/LinkedIn/AccessToken.php
+++ b/src/Happyr/LinkedIn/AccessToken.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Happyr\LinkedIn;
+
+/**
+ * @author Tobias Nyholm
+ */
+class AccessToken
+{
+    /**
+     * @var null|string token
+     */
+    private $token;
+
+    /**
+     * @var \DateTime expiresAt
+     */
+    private $expiresAt;
+
+    /**
+     * @param string    $token
+     * @param \DateTime $expiresIn
+     */
+    public function __construct($token = null, \DateTime $expiresIn = null)
+    {
+        $this->token = $token;
+        $this->expiresAt = $expiresIn;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->token ?: '';
+    }
+
+    /**
+     * Does a token string exist?
+     *
+     * @return bool
+     */
+    public function hasToken()
+    {
+        return !empty($this->token);
+    }
+
+    /**
+     * @param string $json
+     */
+    public function constructFromJson($json)
+    {
+        $data = json_decode($json, true);
+
+        if (isset($data['access_token'])) {
+            $this->token = $data['access_token'];
+        }
+
+        if (isset($data['expires_in'])) {
+            $this->expiresAt = new \DateTime(sprintf('+%dseconds', $data['expires_in']));
+        }
+    }
+
+    /**
+     * @param \DateTime $expiresAt
+     *
+     * @return $this
+     */
+    public function setExpiresAt($expiresAt)
+    {
+        $this->expiresAt = $expiresAt;
+
+        return $this;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getExpiresAt()
+    {
+        return $this->expiresAt;
+    }
+
+    /**
+     * @param null|string $token
+     *
+     * @return $this
+     */
+    public function setToken($token)
+    {
+        $this->token = $token;
+
+        return $this;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getToken()
+    {
+        return $this->token;
+    }
+}

--- a/src/Happyr/LinkedIn/AccessToken.php
+++ b/src/Happyr/LinkedIn/AccessToken.php
@@ -66,7 +66,7 @@ class AccessToken
      *
      * @return $this
      */
-    public function setExpiresAt($expiresAt)
+    public function setExpiresAt(\DateTime $expiresAt=null)
     {
         $this->expiresAt = $expiresAt;
 

--- a/src/Happyr/LinkedIn/LinkedIn.php
+++ b/src/Happyr/LinkedIn/LinkedIn.php
@@ -63,7 +63,7 @@ class LinkedIn
      * The OAuth access token received in exchange for a valid authorization
      * code.  null means the access token has yet to be determined.
      *
-     * @var string
+     * @var AccessToken
      */
     protected $accessToken = null;
 
@@ -325,7 +325,7 @@ class LinkedIn
      * Determines the access token that should be used for API calls.
      *
      *
-     * @return string|null The access token of null if the access token is not found
+     * @return AccessToken|null The access token of null if the access token is not found
      */
     public function getAccessToken()
     {
@@ -387,7 +387,7 @@ class LinkedIn
      * @param string $redirectUri Where the user should be redirected after token is generated.
      *                            Default is the current url
      *
-     * @return string|null An access token exchanged for the authorization code, or
+     * @return AccessToken|null An access token exchanged for the authorization code, or
      *               null if an access token could not be generated.
      */
     protected function getAccessTokenFromCode($code, $redirectUri = null)
@@ -426,12 +426,14 @@ class LinkedIn
             return null;
         }
 
-        $responseArray = json_decode($response, true);
-        if (!isset($responseArray['access_token'])) {
+        $token = new AccessToken();
+        $token->constructFromJson($response);
+
+        if (!$token->hasToken()) {
             return null;
         }
 
-        return $responseArray['access_token'];
+        return $token;
     }
 
     /**
@@ -515,12 +517,16 @@ class LinkedIn
     /**
      * Get the access token
      *
-     * @param string $accessToken
+     * @param string|AccessToken $accessToken
      *
      * @return $this
      */
     public function setAccessToken($accessToken)
     {
+        if (!($accessToken instanceof AccessToken)) {
+            $accessToken = new AccessToken($accessToken);
+        }
+
         $this->accessToken = $accessToken;
 
         return $this;

--- a/tests/Happyr/LinkedIn/AccessTokenTest.php
+++ b/tests/Happyr/LinkedIn/AccessTokenTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Happyr\LinkedIn;
+
+/**
+ * @author Tobias Nyholm
+ */
+class AccessTokenTest extends \PHPUnit_Framework_TestCase
+{
+    public function testToString()
+    {
+        $token = new AccessToken();
+        $this->assertEquals('', $token);
+
+        $token->setToken('foobar');
+        $this->assertEquals('foobar', $token);
+    }
+
+    public function testConstructFromJson()
+    {
+        $token = new AccessToken();
+        $token->constructFromJson(json_encode(array('access_token'=>'foobar', 'expires_in'=>10)));
+
+        $this->assertInstanceOf('\DateTime', $token->getExpiresAt());
+        $this->assertEquals('foobar', $token->getToken());
+
+        $token = new AccessToken();
+        $token->constructFromJson(json_encode(array('baz'=>'foobar')));
+
+        $this->assertNull($token->getExpiresAt());
+        $this->assertEmpty($token->getToken());
+    }
+}

--- a/tests/Happyr/LinkedIn/LinkedInTest.php
+++ b/tests/Happyr/LinkedIn/LinkedInTest.php
@@ -227,11 +227,11 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
     public function testGetAccessTokenFromCode()
     {
         $code='code';
-        $response=json_encode(array('access_token'=>'foobar'));
+        $response=json_encode(array('access_token'=>'foobar', 'expires_in'=>10));
         $linkedIn = $this->prepareGetAccessTokenFromCode($code, $response);
 
-        $this->assertEquals('foobar', $linkedIn->getAccessTokenFromCode($code), 'Standard get access token form code');
-
+        $token = $linkedIn->getAccessTokenFromCode($code);
+        $this->assertEquals('foobar', $token, 'Standard get access token form code');
 
         $response=json_encode(array('foo'=>'bar'));
         $linkedIn = $this->prepareGetAccessTokenFromCode($code, $response);
@@ -242,6 +242,7 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
         $linkedIn = $this->prepareGetAccessTokenFromCode($code, $response);
 
         $this->assertNull($linkedIn->getAccessTokenFromCode($code), 'Empty result');
+        $this->assertNull($linkedIn->getAccessTokenFromCode(null), 'Empty result');
 
     }
 


### PR DESCRIPTION
This address issue #33. 
With a token object you will have the expireAt data for the token. This PR is also backwards compatible. You can still use `LinkedIn::setAccessToken` with a string ([see code](https://github.com/Happyr/LinkedIn-API-client/blob/da64edb2c519587d950d37170c9b81e2dd917798/src/Happyr/LinkedIn/LinkedIn.php#L526))