### PR TITLE
Make session storage injectable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ build
 phpunit.xml
 composer.lock
 vendor
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 phpunit.xml
 composer.lock
 vendor
+.idea

--- a/Readme.md
+++ b/Readme.md
@@ -99,7 +99,7 @@ use \Happyr\LinkedIn\Storage\DataStorageInterface;
 
 class CacheManagerHappyrLinkedInAdapter implements DataStorageInterface
 {
-	public function __construct($cacheManager) {}
+	public function __construct() {}
 
 	/**
 	 * {@inheritDoc}

--- a/Readme.md
+++ b/Readme.md
@@ -85,6 +85,64 @@ echo "<a href='$url'>Login with LinkedIn</a>";
 
 ```
 
+You can easily implement your own session storage device and use it with this library. Just make sure your session
+storage class implements the `\Happyr\LinkedIn\Storage\DataStorageInterface` interface (or write an adapter that
+uses your class and implements that interface as shown below).
+
+```php
+<?php
+
+/**
+ * First write a class or an adapter that implements DataStorageInterface
+ */
+use \Happyr\LinkedIn\Storage\DataStorageInterface;
+
+class CacheManagerHappyrLinkedInAdapter implements DataStorageInterface
+{
+	public function __construct($cacheManager) {}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param string $key
+	 * @param array $value
+	 * @return void
+	 */
+	public function set($key, $value) {}
+
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @param string $key
+	 * @param mixed $default
+	 * @return mixed
+	 */
+	public function get($key, $default = false) {}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param string $key
+	 * @return void
+	 */
+	public function clear($key) {}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return void
+	 */
+	public function clearAll() {}
+}
+
+/**
+ * Now you can use your custom class as the session storage for this library
+ */
+$linkedIn=new Happyr\LinkedIn\LinkedIn('app_id', 'app_secret');
+// The line of code below is how you tell the library to use your custom session storage
+$linkedIn->setStorage(new CacheManagerHappyrLinkedInAdapter());
+
+```
 
 ### Framework integration
 

--- a/src/Happyr/LinkedIn/LinkedIn.php
+++ b/src/Happyr/LinkedIn/LinkedIn.php
@@ -90,31 +90,41 @@ class LinkedIn
      *
      * @param string $appId
      * @param string $appSecret
+     * @param null|DataStorageInterface $storage
      */
-    public function __construct($appId, $appSecret)
+    public function __construct($appId, $appSecret, $storage = null)
     {
+        if ($storage && !($storage instanceof DataStorageInterface)) {
+            throw new \InvalidArgumentException('\$storage has to be an instance of DataStorageInterface');
+        }
         //save app stuff
         $this->appId = $appId;
         $this->appSecret = $appSecret;
 
-        $this->init();
+        $this->init($storage);
     }
 
     /**
      * Init the API by creating some classes.
      *
      * This function could be overwritten if you want to change any of these classes
+     * 
+     * @param null|DataStorageInterface $storage
      */
-    protected function init()
+    protected function init($storage = null)
     {
         $this->urlGenerator = new UrlGenerator();
         $this->request = new GuzzleRequest();
 
-        // Use the Illuminate Session storage if it is available
-        if (class_exists('\Illuminate\Support\Facades\Session')) {
-            $this->storage = new IlluminateSessionStorage();
+        if ($storage) {
+            $this->storage = $storage;
         } else {
-            $this->storage = new SessionStorage();
+            // Use the Illuminate Session storage if it is available
+            if (class_exists('\Illuminate\Support\Facades\Session')) {
+                $this->storage = new IlluminateSessionStorage();
+            } else {
+                $this->storage = new SessionStorage();
+            }
         }
     }
 

--- a/src/Happyr/LinkedIn/LinkedIn.php
+++ b/src/Happyr/LinkedIn/LinkedIn.php
@@ -90,29 +90,25 @@ class LinkedIn
      *
      * @param string $appId
      * @param string $appSecret
-     * @param DataStorageInterface $storage [optional] the session storage object to use
      */
-    public function __construct($appId, $appSecret, DataStorageInterface $storage=null)
+    public function __construct($appId, $appSecret)
     {
         //save app stuff
         $this->appId = $appId;
         $this->appSecret = $appSecret;
 
-        $this->init($storage);
+        $this->init();
     }
 
     /**
      * Init the API by creating some classes.
      *
      * This function could be overwritten if you want to change any of these classes
-     * 
-     * @param DataStorageInterface $storage [optional] the session storage object to use
      */
-    protected function init(DataStorageInterface $storage=null)
+    protected function init()
     {
         $this->urlGenerator = new UrlGenerator();
         $this->request = new GuzzleRequest();
-        $this->storage = $storage;
     }
 
     /**
@@ -572,7 +568,7 @@ class LinkedIn
      */
     public function getStorage()
     {
-        if (null == $this->storage) {
+        if (null === $this->storage) {
             $this->storage = new SessionStorage();
         }
         return $this->storage;

--- a/src/Happyr/LinkedIn/LinkedIn.php
+++ b/src/Happyr/LinkedIn/LinkedIn.php
@@ -572,9 +572,9 @@ class LinkedIn
      */
     public function getStorage()
     {
-	    if (null == $this->storage) {
-		    $this->storage = new SessionStorage();
-	    }
+        if (null == $this->storage) {
+            $this->storage = new SessionStorage();
+        }
         return $this->storage;
     }
 

--- a/src/Happyr/LinkedIn/LinkedIn.php
+++ b/src/Happyr/LinkedIn/LinkedIn.php
@@ -90,7 +90,7 @@ class LinkedIn
      *
      * @param string $appId
      * @param string $appSecret
-     * @param null|DataStorageInterface $storage
+     * @param DataStorageInterface $storage [optional] the session storage object to use
      */
     public function __construct($appId, $appSecret, $storage = null)
     {
@@ -109,7 +109,7 @@ class LinkedIn
      *
      * This function could be overwritten if you want to change any of these classes
      * 
-     * @param null|DataStorageInterface $storage
+     * @param DataStorageInterface $storage [optional] the session storage object to use
      */
     protected function init($storage = null)
     {

--- a/src/Happyr/LinkedIn/LinkedIn.php
+++ b/src/Happyr/LinkedIn/LinkedIn.php
@@ -112,12 +112,7 @@ class LinkedIn
     {
         $this->urlGenerator = new UrlGenerator();
         $this->request = new GuzzleRequest();
-
-        if ($storage) {
-            $this->storage = $storage;
-        } else {
-            $this->storage = new SessionStorage();
-        }
+        $this->storage = $storage;
     }
 
     /**
@@ -577,6 +572,9 @@ class LinkedIn
      */
     public function getStorage()
     {
+	    if (null == $this->storage) {
+		    $this->storage = new SessionStorage();
+	    }
         return $this->storage;
     }
 

--- a/src/Happyr/LinkedIn/LinkedIn.php
+++ b/src/Happyr/LinkedIn/LinkedIn.php
@@ -92,11 +92,8 @@ class LinkedIn
      * @param string $appSecret
      * @param DataStorageInterface $storage [optional] the session storage object to use
      */
-    public function __construct($appId, $appSecret, $storage = null)
+    public function __construct($appId, $appSecret, DataStorageInterface $storage=null)
     {
-        if ($storage && !($storage instanceof DataStorageInterface)) {
-            throw new \InvalidArgumentException('\$storage has to be an instance of DataStorageInterface');
-        }
         //save app stuff
         $this->appId = $appId;
         $this->appSecret = $appSecret;
@@ -111,7 +108,7 @@ class LinkedIn
      * 
      * @param DataStorageInterface $storage [optional] the session storage object to use
      */
-    protected function init($storage = null)
+    protected function init(DataStorageInterface $storage=null)
     {
         $this->urlGenerator = new UrlGenerator();
         $this->request = new GuzzleRequest();
@@ -119,12 +116,7 @@ class LinkedIn
         if ($storage) {
             $this->storage = $storage;
         } else {
-            // Use the Illuminate Session storage if it is available
-            if (class_exists('\Illuminate\Support\Facades\Session')) {
-                $this->storage = new IlluminateSessionStorage();
-            } else {
-                $this->storage = new SessionStorage();
-            }
+            $this->storage = new SessionStorage();
         }
     }
 

--- a/tests/Happyr/LinkedIn/LinkedInTest.php
+++ b/tests/Happyr/LinkedIn/LinkedInTest.php
@@ -37,12 +37,24 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException InvalidArgumentException
      * @expectedExceptionMessageRegExp #.*must implement.*DataStorageInterface.*#
      */
     public function testConstructorThrowsExceptionIfWrongStorageTypeIsPassed()
     {
+        set_error_handler(function($errno, $errstr) {
+            // This is a one time error handler, so we need to restore the previous one if we end up in here.
+            restore_error_handler();
+            if (E_RECOVERABLE_ERROR === $errno) {
+                throw new \InvalidArgumentException($errstr, $errno);
+                return true;
+            }
+            return false;
+        });
         new LinkedIn(self::APP_ID, self::APP_SECRET, new \stdClass());
+        // Don't forget to restore the error handler to its previous value even if we don't hit an error above. If we
+        // do hit an error, this line won't ever be reached, so we'll only restore the error handler once either way
+        restore_error_handler();
     }
     
     public function testInitProperlyAssignsPassedInStorage()

--- a/tests/Happyr/LinkedIn/LinkedInTest.php
+++ b/tests/Happyr/LinkedIn/LinkedInTest.php
@@ -3,6 +3,7 @@
 namespace Happyr\LinkedIn;
 
 use Happyr\LinkedIn\Exceptions\LinkedInApiException;
+use Happyr\LinkedIn\Storage\DataStorageInterface;
 use Happyr\LinkedIn\Storage\SessionStorage;
 use Mockery as m;
 
@@ -36,8 +37,8 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessageRegExp #.*\$storage.*DataStorageInterface.*#
+     * @expectedException PHPUnit_Framework_Error
+     * @expectedExceptionMessageRegExp #.*must implement.*DataStorageInterface.*#
      */
     public function testConstructorThrowsExceptionIfWrongStorageTypeIsPassed()
     {
@@ -49,6 +50,12 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
         $sessionStorage = new SessionStorage();
         $ln = new LinkedIn(self::APP_ID, self::APP_SECRET, $sessionStorage);
         $this->assertEquals($sessionStorage, $ln->getStorage());
+    }
+
+    public function testInitProperlyUsesSessionStorageObjectByDefault()
+    {
+        $ln = new LinkedIn(self::APP_ID, self::APP_SECRET);
+        $this->assertInstanceOf('Happyr\LinkedIn\Storage\SessionStorage', $ln->getStorage());
     }
 
     public function testApi()
@@ -566,7 +573,7 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
  */
 class LinkedInDummy extends LinkedIn
 {
-    public function init($storage=null, $request=null, $generator=null)
+    public function init(DataStorageInterface $storage=null, $request=null, $generator=null)
     {
         if (!$storage) {
             $storage = m::mock('Happyr\LinkedIn\Storage\DataStorageInterface');

--- a/tests/Happyr/LinkedIn/LinkedInTest.php
+++ b/tests/Happyr/LinkedIn/LinkedInTest.php
@@ -4,6 +4,7 @@ namespace Happyr\LinkedIn;
 
 use Happyr\LinkedIn\Exceptions\LinkedInApiException;
 use Happyr\LinkedIn\Storage\DataStorageInterface;
+use Happyr\LinkedIn\Storage\IlluminateSessionStorage;
 use Happyr\LinkedIn\Storage\SessionStorage;
 use Mockery as m;
 
@@ -38,16 +39,30 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
 
     public function testInitProperlyAssignsPassedInStorage()
     {
-        $sessionStorage = new SessionStorage();
+        $sessionStorage = new IlluminateSessionStorage();
         $ln = new LinkedIn(self::APP_ID, self::APP_SECRET, $sessionStorage);
-        $this->assertEquals($sessionStorage, $ln->getStorage());
+	    $this->assertAttributeSame($sessionStorage, 'storage', $ln);
     }
 
     public function testInitProperlyUsesSessionStorageObjectByDefault()
     {
         $ln = new LinkedIn(self::APP_ID, self::APP_SECRET);
-        $this->assertInstanceOf('Happyr\LinkedIn\Storage\SessionStorage', $ln->getStorage());
+	    $this->assertAttributeEquals(null, 'storage', $ln);
     }
+	
+	public function testGetStorageProperlyReturnsStoredMemberVariable()
+	{
+		$sessionStorage = new IlluminateSessionStorage();
+		$ln = new LinkedIn(self::APP_ID, self::APP_SECRET);
+		$ln->setStorage($sessionStorage);
+		$this->assertSame($sessionStorage, $ln->getStorage());
+	}
+
+	public function testGetStorageProperlyReturnsDefaultMemberVariable()
+	{
+		$ln = new LinkedIn(self::APP_ID, self::APP_SECRET);
+		$this->assertInstanceOf('Happyr\LinkedIn\Storage\SessionStorage', $ln->getStorage());
+	}
 
     public function testApi()
     {

--- a/tests/Happyr/LinkedIn/LinkedInTest.php
+++ b/tests/Happyr/LinkedIn/LinkedInTest.php
@@ -41,28 +41,28 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
     {
         $sessionStorage = new IlluminateSessionStorage();
         $ln = new LinkedIn(self::APP_ID, self::APP_SECRET, $sessionStorage);
-	    $this->assertAttributeSame($sessionStorage, 'storage', $ln);
+        $this->assertAttributeSame($sessionStorage, 'storage', $ln);
     }
 
     public function testInitProperlyUsesSessionStorageObjectByDefault()
     {
         $ln = new LinkedIn(self::APP_ID, self::APP_SECRET);
-	    $this->assertAttributeEquals(null, 'storage', $ln);
+        $this->assertAttributeEquals(null, 'storage', $ln);
     }
-	
-	public function testGetStorageProperlyReturnsStoredMemberVariable()
-	{
-		$sessionStorage = new IlluminateSessionStorage();
-		$ln = new LinkedIn(self::APP_ID, self::APP_SECRET);
-		$ln->setStorage($sessionStorage);
-		$this->assertSame($sessionStorage, $ln->getStorage());
-	}
 
-	public function testGetStorageProperlyReturnsDefaultMemberVariable()
-	{
-		$ln = new LinkedIn(self::APP_ID, self::APP_SECRET);
-		$this->assertInstanceOf('Happyr\LinkedIn\Storage\SessionStorage', $ln->getStorage());
-	}
+    public function testGetStorageProperlyReturnsStoredMemberVariable()
+    {
+        $sessionStorage = new IlluminateSessionStorage();
+        $ln = new LinkedIn(self::APP_ID, self::APP_SECRET);
+        $ln->setStorage($sessionStorage);
+        $this->assertSame($sessionStorage, $ln->getStorage());
+    }
+
+    public function testGetStorageProperlyReturnsDefaultMemberVariable()
+    {
+        $ln = new LinkedIn(self::APP_ID, self::APP_SECRET);
+        $this->assertInstanceOf('Happyr\LinkedIn\Storage\SessionStorage', $ln->getStorage());
+    }
 
     public function testApi()
     {

--- a/tests/Happyr/LinkedIn/LinkedInTest.php
+++ b/tests/Happyr/LinkedIn/LinkedInTest.php
@@ -37,14 +37,7 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
             'Expect the API secret to be set.');
     }
 
-    public function testInitProperlyAssignsPassedInStorage()
-    {
-        $sessionStorage = new IlluminateSessionStorage();
-        $ln = new LinkedIn(self::APP_ID, self::APP_SECRET, $sessionStorage);
-        $this->assertAttributeSame($sessionStorage, 'storage', $ln);
-    }
-
-    public function testInitProperlyUsesSessionStorageObjectByDefault()
+    public function testInitDoesNotAssignSessionStorageByDefault()
     {
         $ln = new LinkedIn(self::APP_ID, self::APP_SECRET);
         $this->assertAttributeEquals(null, 'storage', $ln);

--- a/tests/Happyr/LinkedIn/LinkedInTest.php
+++ b/tests/Happyr/LinkedIn/LinkedInTest.php
@@ -36,27 +36,6 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
             'Expect the API secret to be set.');
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessageRegExp #.*must implement.*DataStorageInterface.*#
-     */
-    public function testConstructorThrowsExceptionIfWrongStorageTypeIsPassed()
-    {
-        set_error_handler(function($errno, $errstr) {
-            // This is a one time error handler, so we need to restore the previous one if we end up in here.
-            restore_error_handler();
-            if (E_RECOVERABLE_ERROR === $errno) {
-                throw new \InvalidArgumentException($errstr, $errno);
-                return true;
-            }
-            return false;
-        });
-        new LinkedIn(self::APP_ID, self::APP_SECRET, new \stdClass());
-        // Don't forget to restore the error handler to its previous value even if we don't hit an error above. If we
-        // do hit an error, this line won't ever be reached, so we'll only restore the error handler once either way
-        restore_error_handler();
-    }
-    
     public function testInitProperlyAssignsPassedInStorage()
     {
         $sessionStorage = new SessionStorage();

--- a/tests/Happyr/LinkedIn/LinkedInTest.php
+++ b/tests/Happyr/LinkedIn/LinkedInTest.php
@@ -35,6 +35,22 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
             'Expect the API secret to be set.');
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessageRegExp #.*\$storage.*DataStorageInterface.*#
+     */
+    public function testConstructorThrowsExceptionIfWrongStorageTypeIsPassed()
+    {
+        new LinkedIn(self::APP_ID, self::APP_SECRET, new \stdClass());
+    }
+    
+    public function testInitProperlyAssignsPassedInStorage()
+    {
+        $sessionStorage = new SessionStorage();
+        $ln = new LinkedIn(self::APP_ID, self::APP_SECRET, $sessionStorage);
+        $this->assertEquals($sessionStorage, $ln->getStorage());
+    }
+
     public function testApi()
     {
         $resource='resource';


### PR DESCRIPTION
These changes will make the session storage object injectable into the `LinkedIn` class. This will allow developers to write custom implementations of the `DataStorageInterface` interface and use them with this library without having to modify any source code. This will allow developers to bring this package into their project (and keep it updated) via composer while implementing the concrete session storage logic inside of their own project.

The code explicitly enforces the passed in `$storage` variable to be of type `DataStorageInterface`, so the rest of the package can safely remain oblivious of the concrete implementation and keep using it through the interface.