### PR TITLE
Fix null token returned

### DIFF
--- a/src/LinkedIn.php
+++ b/src/LinkedIn.php
@@ -24,7 +24,7 @@ use Happyr\LinkedIn\Storage\SessionStorage;
  * 7. fetchNewAccessToken() gets the *code* and calls getAccessTokenFromCode()
  * 8. getAccessTokenFromCode() makes a request to www.linkedin.com and exchanges the *code* for an access token
  * 9. With a valid access token we can query the api for the user
- * 10. When yuo make a second request to the api you skip the authorization (1-3) and
+ * 10. When you make a second request to the api you skip the authorization (1-3) and
  *     the "*code* for access token exchange" (6-8).
  *
  * @author Tobias Nyholm
@@ -334,7 +334,7 @@ class LinkedIn
     public function getAccessToken()
     {
         if ($this->accessToken !== null) {
-            // we've done this already and cached it.  Just return.
+            // we've done this already and cached it. Just return.
             return $this->accessToken;
         }
 
@@ -343,7 +343,7 @@ class LinkedIn
             $this->setAccessToken($newAccessToken);
         }
 
-        //return the new access token or null
+        // return the new access token or null
         return $this->accessToken;
     }
 
@@ -439,7 +439,7 @@ class LinkedIn
             return;
         }
 
-        return $token;
+        return $token->getToken();
     }
 
     /**
@@ -525,10 +525,6 @@ class LinkedIn
      */
     public function setAccessToken($accessToken)
     {
-        if (!($accessToken instanceof AccessToken)) {
-            $accessToken = new AccessToken($accessToken);
-        }
-
         $this->accessToken = $accessToken;
 
         return $this;

--- a/src/LinkedIn.php
+++ b/src/LinkedIn.php
@@ -361,7 +361,7 @@ class LinkedIn
         $code = $this->getCode();
 
         if ($code !== null) {
-            $accessToken = $this->getAccessTokenFromCode($code);
+            $accessToken = (string)$this->getAccessTokenFromCode($code);
             if ($accessToken) {
                 $storage->set('code', $code);
                 $storage->set('access_token', $accessToken);
@@ -439,7 +439,7 @@ class LinkedIn
             return;
         }
 
-        return $token->getToken();
+        return $token;
     }
 
     /**


### PR DESCRIPTION
Token is returned correctly now (it was not «propagated» to object, and not given to the storage (session by default)).