### PR TITLE
Make sure we can have query string in the endpoint.

### DIFF
--- a/src/Http/UrlGenerator.php
+++ b/src/Http/UrlGenerator.php
@@ -53,13 +53,16 @@ class UrlGenerator implements UrlGeneratorInterface
         }
 
         if (!empty($params)) {
-            //it needs to be PHP_QUERY_RFC3986. We want to have %20 between scopes
-            // we cant run http_build_query($params, null, '&', PHP_QUERY_RFC3986); because it is not supported in php 5.3 or hhvm
-            $url .= '?';
-            foreach ($params as $key => $value) {
-                $url .= sprintf('%s=%s&', rawurlencode($key), rawurlencode($value));
+            // does it exist a query string?
+            $queryString = parse_url($url, PHP_URL_QUERY);
+            if (empty($queryString)) {
+                $url .= '?';
+            } else {
+                $url .= '&';
             }
-            $url = rtrim($url, '&');
+
+            // it needs to be PHP_QUERY_RFC3986. We want to have %20 between scopes
+            $url .= http_build_query($params, null, '&', PHP_QUERY_RFC3986);
         }
 
         return $url;

--- a/tests/Http/UrlGeneratorTest.php
+++ b/tests/Http/UrlGeneratorTest.php
@@ -75,6 +75,18 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEquals($notExpected, $gen->getUrl('api', 'foobar', array('bar' => 'baz a b')), 'Dont use PHP_QUERY_RFC1738');
     }
 
+    public function testGetUrlWithParams()
+    {
+        $gen = new UrlGenerator();
+
+        $expected = 'https://api.linkedin.com/endpoint?bar=baz&format=json';
+        $this->assertEquals($expected, $gen->getUrl('api', 'endpoint?bar=baz', array('format' => 'json')));
+
+        $expected = 'https://api.linkedin.com/endpoint?bar=baz&bar=baz';
+        $this->assertEquals($expected, $gen->getUrl('api', 'endpoint?bar=baz', array('bar' => 'baz')));
+
+    }
+
     public function testGetCurrentURL()
     {
         $gen = $this->getMock('Happyr\LinkedIn\Http\UrlGenerator', array('getHttpProtocol', 'getHttpHost', 'dropLinkedInParams'), array());


### PR DESCRIPTION
This will resolve issue #55.

Previous behavior: 
``` php
https://api.linkedin.com/v1/companies?is-company-admin=true
// converts to:
https://api.linkedin.com/v1/companies?is-company-admin=true?format=json
```
New behavior: 
``` php
https://api.linkedin.com/v1/companies?is-company-admin=true
// converts to:
https://api.linkedin.com/v1/companies?is-company-admin=true&format=json
```
Note the ampersand instead of question mark. 