### PR TITLE
Minor fix for error handling

### DIFF
--- a/src/Http/GuzzleRequest.php
+++ b/src/Http/GuzzleRequest.php
@@ -114,7 +114,11 @@ class GuzzleRequest implements RequestInterface
             };
         }
 
-        return (string) $response->xml()->message;
+        try {
+            return (string)$response->xml()->message;
+        } catch (\Exception $ex) {
+            return 'Excpetion while processing error response. Error reason phrase: ' . $response->getReasonPhrase();
+        }
     }
 
     /**


### PR DESCRIPTION
There might be a nicer/cleaner way to do this. However, this is to address the problem that the LinkedIn API returns HTML on certain errors, including 404's. When that happens, the XML parser can't handle it, and throws an exception.

The effect was that 404's appear as XML parsing exceptions, which is unintuitive and weird.