### PR TITLE
Remove php-http/message and prepare for stable release

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -45,6 +45,11 @@ released). You could use Guzzles PSR-7 implementation and factories from php-htt
 composer require guzzlehttp/psr7 php-http/message 
 ```
 
+Now you may install the library by running the following:
+
+```bash
+composer require happyr/linkedin-api-client
+```
 
 If you are updating form a previous version make sure to read [the upgrade documentation](Upgrade.md).
 

--- a/Readme.md
+++ b/Readme.md
@@ -28,12 +28,6 @@ Here is a list of features that might convince you to choose this LinkedIn clien
 
 ## Installation
 
-Install the library with Composer. 
-
-```bash
-composer require happyr/linkedin-api-client
-```
-
 This library does not have a dependency on Guzzle or any other library that sends HTTP requests. We use the awesome 
 HTTPlug to achieve the decoupling. We want you to choose what library to use for sending HTTP requests. Consult this list 
 ofthis list virtual packages that support [php-http/client-implementation](https://packagist.org/providers/php-http/client-implementation) 
@@ -50,6 +44,7 @@ released). You could use Guzzles PSR-7 implementation and factories from php-htt
 ```bash
 composer require guzzlehttp/psr7 php-http/message 
 ```
+
 
 If you are updating form a previous version make sure to read [the upgrade documentation](Upgrade.md).
 

--- a/Readme.md
+++ b/Readme.md
@@ -44,9 +44,16 @@ find clients to use. For more information about virtual packages please refer to
 composer require php-http/guzzle6-adapter
 ```
 
+You do also need to install a PSR-7 implementation and a factory to create PSR-7 messages (PSR-17 whenever that is 
+released). You could use Guzzles PSR-7 implementation and factories from php-http:
+
+```bash
+composer require guzzlehttp/psr7 php-http/message 
+```
+
 If you are updating form a previous version make sure to read [the upgrade documentation](Upgrade.md).
 
-### Finding the HTTP client. 
+### Finding the HTTP client (optional) 
 
 The LinkedIn client need to know what library you are using to send HTTP messages. You could provide an instance of 
 HttpClient and MessageFactory or you could fallback on auto discovery. Below is an example on where you provide a Guzzle6 
@@ -58,7 +65,6 @@ $linkedIn->setHttpClient(new \Http\Adapter\Guzzle6\Client());
 $linkedIn->setHttpMessageFactory(new Http\Message\MessageFactory\GuzzleMessageFactory());
 
 ```
-
 
 ## Usage
 

--- a/Upgrade.md
+++ b/Upgrade.md
@@ -2,6 +2,12 @@
 
 This document explains how you upgrade from one version to another. 
 
+## Upgrade from 0.7.2 to 1.0
+
+### Changes
+
+* We do not longer require `php-http/message`. You have to make sure to put that in your own composer.json.
+
 ## Upgrade from 0.7.1 to 0.7.2
 
 ### Changes

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "php": "^5.5 || ^7.0",
         "php-http/client-implementation": "^1.0",
         "php-http/httplug": "^1.0",
-        "php-http/message": "^1.0",
         "php-http/message-factory": "^1.0",
         "php-http/discovery": "^1.0"
     },
@@ -35,7 +34,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.8.x-dev"
+            "dev-master": "1.1.x-dev"
         }
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | yes
| Related tickets | 
| License         | MIT


#### What's in this PR?

Prepare for a stable release.


#### Why?

We do not actually depend on php-http/message