### PR TITLE
Suggestion

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -94,7 +94,7 @@ This example below is showing how to login with LinkedIn.
  */
 //require_once "vendor/autoload.php";
 
-$linkedIn=new Happyr\LinkedIn\LinkedIn('app_id', 'app_secret');
+$linkedIn=new Happyr\LinkedIn\LinkedIn('client_id', 'client_secret');
 
 if ($linkedIn->isAuthenticated()) {
     //we know that the user is authenticated now. Start query the API


### PR DESCRIPTION
May I suggest the swapping of "app_id" for "client_id" and "app_secret" for "client_secret"? LinkedIn uses "client" instead of "app" in the "My Apps" section of the LinkedIn website. So I think that this change will make it more clear for anyone trying to use this API.