### PR TITLE
remove the host part of the url if it has been passed in as part of $…

### DIFF
--- a/src/Http/UrlGenerator.php
+++ b/src/Http/UrlGenerator.php
@@ -36,6 +36,17 @@ class UrlGenerator implements UrlGeneratorInterface
      */
     public function getUrl($name, $path = '', $params = [])
     {
+        /* handle the user passing in a full URL as the path */
+        $urlComponents = parse_url($path);
+        if (isset($urlComponents['path'])) {
+            if (!empty($urlComponents['host'])) {
+                $path = $urlComponents['path'];
+                if (!empty($urlComponents['query'])) {
+                    $path .= '?' . http_build_query($urlComponents['query']);
+                }
+            }
+        }
+
         $url = self::$domainMap[$name];
         if ($path) {
             if ($path[0] === '/') {

--- a/src/Http/UrlGenerator.php
+++ b/src/Http/UrlGenerator.php
@@ -42,7 +42,7 @@ class UrlGenerator implements UrlGeneratorInterface
             if (!empty($urlComponents['host'])) {
                 $path = $urlComponents['path'];
                 if (!empty($urlComponents['query'])) {
-                    $path .= '?' . http_build_query($urlComponents['query']);
+                    $path .= '?' . $urlComponents['query'];
                 }
             }
         }


### PR DESCRIPTION


| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT


#### What's in this PR?

If someone passes e.g. https://api.linkedin.com/v2/whatever in as the resource parameter, then the underlying code will try and request https://api.linkedin.com/https://api.linkedin.com/v2/whatever ... which unsurprisingly doesn't work.



#### Why?

I wasted some time wondering why it wasn't working ....

#### Example Usage

``` php

$x = new LinkedIn();
// setup.

var_dump($x->get('https://api.linkedin.com/v2/adAccountsV2')) ; // now works.

```
