### PR TITLE
store the lastRequest and lastResponse in the RequestManager; update …

### DIFF
--- a/src/Http/RequestManager.php
+++ b/src/Http/RequestManager.php
@@ -27,14 +27,44 @@ class RequestManager implements RequestManagerInterface
     private $messageFactory;
 
     /**
+     * @var \Psr\Http\Message\RequestInterface
+     */
+    private $lastRequest;
+
+
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $lastResponse;
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLastRequest() {
+        return $this->lastRequest;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLastResponse() {
+        return $this->lastResponse;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function sendRequest($method, $uri, array $headers = [], $body = null, $protocolVersion = '1.1')
     {
         $request = $this->getMessageFactory()->createRequest($method, $uri, $headers, $body, $protocolVersion);
 
+        $this->lastRequest = $request;
+
         try {
-            return $this->getHttpClient()->sendRequest($request);
+            $response = $this->getHttpClient()->sendRequest($request);
+            $this->lastResponse = $response;
+            return $response;
         } catch (TransferException $e) {
             throw new LinkedInTransferException('Error while requesting data from LinkedIn.com: '.$e->getMessage(), $e->getCode(), $e);
         }

--- a/src/Http/RequestManagerInterface.php
+++ b/src/Http/RequestManagerInterface.php
@@ -33,4 +33,20 @@ interface RequestManagerInterface
      * @return RequestManager
      */
     public function setHttpClient(HttpClient $httpClient);
+
+    /**
+     * Get the last request we sent
+     *
+     * @return \Psr\Http\Message\RequestInterface
+     */
+    public function getLastRequest();
+
+
+    /**
+     * Get the last response we received
+     *
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function getLastResponse();
+
 }

--- a/src/LinkedIn.php
+++ b/src/LinkedIn.php
@@ -51,11 +51,6 @@ class LinkedIn implements LinkedInInterface
     private $responseDataType;
 
     /**
-     * @var ResponseInterface
-     */
-    private $lastResponse;
-
-    /**
      * @var RequestManager
      */
     private $requestManager;
@@ -279,14 +274,6 @@ class LinkedIn implements LinkedInInterface
     /**
      * {@inheritdoc}
      */
-    public function getLastResponse()
-    {
-        return $this->lastResponse;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getAccessToken()
     {
         if ($this->accessToken === null) {
@@ -379,5 +366,22 @@ class LinkedIn implements LinkedInInterface
     protected function getAuthenticator()
     {
         return $this->authenticator;
+    }
+
+
+    /**
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function getLastResponse()
+    {
+        return $this->getRequestManager()->getLastResponse();
+    }
+
+    /**
+     * @return \Psr\Http\Message\RequestInterface
+     */
+    public function getLastRequest()
+    {
+        return $this->getRequestManager()->getLastRequest();
     }
 }

--- a/src/LinkedInInterface.php
+++ b/src/LinkedInInterface.php
@@ -7,6 +7,7 @@ use Happyr\LinkedIn\Http\UrlGeneratorInterface;
 use Happyr\LinkedIn\Storage\DataStorageInterface;
 use Http\Client\HttpClient;
 use Http\Message\MessageFactory;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -122,6 +123,13 @@ interface LinkedInInterface
      * @return ResponseInterface|null
      */
     public function getLastResponse();
+
+    /**
+     * Get the last request. This will always return a PSR-7 request no matter of the data type used.
+     *
+     * @return RequestInterface|null
+     */
+    public function getLastRequest();
 
     /**
      * Returns an access token. If we do not have one in memory, try to fetch one from a *code* in the $_REQUEST.


### PR DESCRIPTION


| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | partly
| BC breaks?      | none
| Deprecations?   | none
| Related tickets | none
| License         | MIT


#### What's in this PR?

Allows the user to get the last Request and last Response from the LinkedIn object (via RequestManager). This might be useful if you need to debug a request, or get hold of the X-LI-UUID for support purposes.


#### Why?

Getting the request allowed me to realise what I was doing wrong ....

#### Example Usage

``` php

$x = new LinkedIn();
// <setup /> 
$x->get('https://api.linkedin.com/v2/adAccountsV2'));
echo "" . $x->getLastRequest()->getBody();
var_dump($x->getLastResponse()->getHeaders());
// etc.
```
