### PR TITLE
remove PHPUnit getMock(); replace with Mockery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "phpunit/phpunit": "^4.5 || ^5.0",
         "php-http/guzzle5-adapter": "^1.0",
         "guzzlehttp/psr7": "^1.2",
-        "mockery/mockery": "^0.9",
+        "mockery/mockery": "^1.0",
         "illuminate/support": "^5.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php-http/discovery": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.5 || ^5.0",
+        "phpunit/phpunit": "^5.0",
         "php-http/guzzle5-adapter": "^1.0",
         "guzzlehttp/psr7": "^1.2",
         "mockery/mockery": "^1.0",

--- a/src/LinkedIn.php
+++ b/src/LinkedIn.php
@@ -5,6 +5,7 @@ namespace Happyr\LinkedIn;
 use Happyr\LinkedIn\Exception\LoginError;
 use Happyr\LinkedIn\Http\GlobalVariableGetter;
 use Happyr\LinkedIn\Http\RequestManager;
+use Happyr\LinkedIn\Http\RequestManagerInterface;
 use Happyr\LinkedIn\Http\ResponseConverter;
 use Happyr\LinkedIn\Http\UrlGenerator;
 use Happyr\LinkedIn\Http\UrlGeneratorInterface;
@@ -336,6 +337,15 @@ class LinkedIn implements LinkedInInterface
     }
 
     /**
+     * @param RequestManagerInterface $manager
+     */
+    public function setRequestManager(RequestManagerInterface $manager) {
+        $this->requestManager = $manager;
+
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function setStorage(DataStorageInterface $storage)
@@ -379,5 +389,14 @@ class LinkedIn implements LinkedInInterface
     protected function getAuthenticator()
     {
         return $this->authenticator;
+    }
+
+    /**
+     * @return Authenticator
+     */
+    public function setAuthenticator(AuthenticatorInterface $auth)
+    {
+        $this->authenticator = $auth;
+        return $this;
     }
 }

--- a/src/LinkedIn.php
+++ b/src/LinkedIn.php
@@ -79,13 +79,13 @@ class LinkedIn implements LinkedInInterface
      * @param string $format           'json', 'xml'
      * @param string $responseDataType 'array', 'string', 'simple_xml' 'psr7', 'stream'
      */
-    public function __construct($appId, $appSecret, $format = 'json', $responseDataType = 'array')
+    public function __construct($appId, $appSecret, $format = 'json', $responseDataType = 'array', RequestManagerInterface $requestManager = null, AuthenticatorInterface $authenticator = null)
     {
         $this->format = $format;
         $this->responseDataType = $responseDataType;
 
-        $this->requestManager = new RequestManager();
-        $this->authenticator = new Authenticator($this->requestManager, $appId, $appSecret);
+        $this->requestManager = isset($requestManager) ? $requestManager : new RequestManager();
+        $this->authenticator = isset($authenticator) ? $authenticator : new Authenticator($this->requestManager, $appId, $appSecret);
     }
 
     /**
@@ -391,12 +391,4 @@ class LinkedIn implements LinkedInInterface
         return $this->authenticator;
     }
 
-    /**
-     * @return Authenticator
-     */
-    public function setAuthenticator(AuthenticatorInterface $auth)
-    {
-        $this->authenticator = $auth;
-        return $this;
-    }
 }

--- a/tests/LinkedInTest.php
+++ b/tests/LinkedInTest.php
@@ -41,11 +41,10 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
         $requestManager->shouldReceive('sendRequest')->once()->withArgs([$method, $url, $headers, json_encode($postParams)])->andReturn($response);
 
 
-        $linkedIn = m::mock(LinkedIn::class, [self::APP_ID, self::APP_SECRET])->makePartial();
+        $linkedIn = m::mock(LinkedIn::class, [self::APP_ID, self::APP_SECRET, 'json', 'array', $requestManager])->makePartial();
         $linkedIn->shouldReceive('getAccessToken')->once()->andREturn($token);
 
         $linkedIn->setUrlGenerator($mockGenerator);
-        $linkedIn->setRequestManager($requestManager);
 
         $result = $linkedIn->api($method, $resource, ['query' => $urlParams, 'json' => $postParams]);
         $this->assertEquals($expected, $result);
@@ -81,9 +80,7 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
         $auth->shouldReceive('fetchNewAccessToken')->once()->andREturn($token);
 
 
-        $linkedIn = new LinkedIn(self::APP_ID, self::APP_SECRET);
-        $linkedIn->setAuthenticator($auth);
-
+        $linkedIn = new LinkedIn(self::APP_ID, self::APP_SECRET, 'json', 'array', null, $auth);
 
         // Make sure we go to the authenticator only once
         $this->assertEquals($token, $linkedIn->getAccessToken());
@@ -184,14 +181,12 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
         $generator = m::mock(UrlGenerator::class)->makePartial();
         $generator->shouldReceive('getLoginUrl')->withAnyArgs()->andReturn($loginUrl);
 
-
         $mockAuth = m::mock(Authenticator::class)->makePartial();
         $mockAuth->shouldReceive('getLoginUrl')->once()->withArgs([$generator, ['redirect_uri' => $otherUrl]])->andReturn($otherUrl);
 
 
-        $linkedIn = new LinkedIn(self::APP_ID, self::APP_SECRET);
+        $linkedIn = new LinkedIn(self::APP_ID, self::APP_SECRET, 'json', 'array', null, $mockAuth);
         $linkedIn->setUrlGenerator($generator);
-        $linkedIn->setAuthenticator($mockAuth);
 
 
         $this->assertContains($otherUrl, $linkedIn->getLoginUrl(['redirect_uri' => $otherUrl]));


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | sort of (tests)
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT


#### What's in this PR?

Change of LinkedInTest to use Mockery.
Removes deprecation warnings from PHPUnit.


#### Why?

phpunit is now less verbose.


#### To Do

- all the other tests that use getMock()....