### PR TITLE
Fix #61. Serialize data in session : object saved in session return _…

### DIFF
--- a/src/Storage/SessionStorage.php
+++ b/src/Storage/SessionStorage.php
@@ -27,7 +27,7 @@ class SessionStorage extends BaseDataStorage
         $this->validateKey($key);
 
         $name = $this->getStorageKeyId($key);
-        $_SESSION[$name] = $value;
+        $_SESSION[$name] = serialize($value);
     }
 
     /**
@@ -38,7 +38,7 @@ class SessionStorage extends BaseDataStorage
         $this->validateKey($key);
         $name = $this->getStorageKeyId($key);
 
-        return isset($_SESSION[$name]) ? $_SESSION[$name] : null;
+        return isset($_SESSION[$name]) ? unserialize($_SESSION[$name]) : null;
     }
 
     /**

--- a/tests/Storage/SessionStorageTest.php
+++ b/tests/Storage/SessionStorageTest.php
@@ -26,7 +26,7 @@ class SessionStorageTest extends \PHPUnit_Framework_TestCase
     public function testSet()
     {
         $this->storage->set('code', 'foobar');
-        $this->assertEquals($_SESSION[$this->prefix.'code'], 'foobar');
+        $this->assertEquals($_SESSION[$this->prefix.'code'], serialize('foobar'));
     }
 
     /**
@@ -43,10 +43,9 @@ class SessionStorageTest extends \PHPUnit_Framework_TestCase
         $result = $this->storage->get('state');
         $this->assertNull($result);
 
-        $expected = 'foobar';
-        $_SESSION[$this->prefix.'code'] = $expected;
+        $_SESSION[$this->prefix.'code'] = serialize('foobar');
         $result = $this->storage->get('code');
-        $this->assertEquals($expected, $result);
+        $this->assertEquals('foobar', $result);
     }
 
     public function testClear()


### PR DESCRIPTION
…_PHP_Incomplete_Class_Name

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | mentioned in #61, #148
| License         | MIT


#### What's in this PR?

In my case (Standard Amazon AMI Linux) 
when an object in stored in session it return a __PHP_Incomplete_Class_Name when I try to get again the class

It's better to serialize/unserialize the data in session

Regards
